### PR TITLE
add parameter 'timeOut' to FaxService

### DIFF
--- a/popbill/faxService.py
+++ b/popbill/faxService.py
@@ -16,13 +16,13 @@ from .base import PopbillBase, PopbillException, File
 class FaxService(PopbillBase):
     """ 팝빌 팩스 API Service Implementation. """
 
-    def __init__(self, LinkID, SecretKey):
+    def __init__(self, LinkID, SecretKey, timeOut=15):
         """생성자
             args
                 LinkID : 링크허브에서 발급받은 링크아이디(LinkID)
                 SecretKeye 링크허브에서 발급받은 비밀키(SecretKey)
         """
-        super(self.__class__, self).__init__(LinkID, SecretKey)
+        super(self.__class__, self).__init__(LinkID, SecretKey, timeOut)
         self._addScope("160")
 
     def getChargeInfo(self, CorpNum, UserID=None):


### PR DESCRIPTION
The current implementation has [an issue](https://github.com/linkhub-sdk/popbill.py/issues/3) when working with multiple threads try to use the same connection. This can be solved by explicitly setting `timeOut` to `0` so that every time the instance calls fax API, it creates and uses a new connection - `httpclient.HTTPSConnection()`.